### PR TITLE
powermock-605 Please support @TestSubject 

### DIFF
--- a/api/easymock/src/main/java/org/powermock/api/easymock/EasyMockConfiguration.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/EasyMockConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.easymock;
+
+/**
+ * Configuration information about EasyMock framework and which feature is supported by version of EasyMock in runtime.
+ *
+ * @since 1.6.5
+ */
+public class EasyMockConfiguration {
+
+    private static final EasyMockConfiguration INSTANCE = new EasyMockConfiguration();
+    private boolean testSubjectSupported;
+    private boolean reallyEasyMock;
+    private boolean injectMocksSupported;
+
+    private EasyMockConfiguration() {
+        initTestSubjectSupported();
+        initReallyEasyMock();
+        initInjectMocksSupported();
+    }
+
+    public static EasyMockConfiguration getConfiguration() {
+        return INSTANCE;
+    }
+    
+    private void initTestSubjectSupported() {
+        try {
+            Class.forName("org.easymock.TestSubject");
+            testSubjectSupported = true;
+        } catch (ClassNotFoundException e) {
+            testSubjectSupported = false;
+        }
+    }
+
+    private void initReallyEasyMock() {
+        try {
+            Class.forName("org.easymock.EasyMockSupport");
+            reallyEasyMock = true;
+        } catch (ClassNotFoundException e) {
+            reallyEasyMock = false;
+        }
+    }
+
+    private void initInjectMocksSupported() {
+        try {
+            Class<?> clazz = Class.forName("org.easymock.EasyMockSupport");
+            clazz.getDeclaredMethod("injectMocks", Object.class);
+            injectMocksSupported = true;
+        } catch (NoSuchMethodException e) {
+            injectMocksSupported = false;
+        } catch (ClassNotFoundException e) {
+            injectMocksSupported = false;
+        }
+    }
+
+    public boolean isInjectMocksSupported() {
+        return injectMocksSupported;
+    }
+
+    public boolean isReallyEasyMock() {
+        return reallyEasyMock;
+    }
+
+    public boolean isTestSubjectSupported() {
+        return testSubjectSupported;
+    }
+}

--- a/api/easymock/src/main/java/org/powermock/api/easymock/annotation/Mock.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/annotation/Mock.java
@@ -2,7 +2,11 @@ package org.powermock.api.easymock.annotation;
 
 import org.powermock.core.classloader.annotations.PowerMockListener;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * This annotation can be placed on those fields in your test class that should
@@ -39,7 +43,7 @@ import java.lang.annotation.*;
  * 
  * <pre>
  * ...
- * &#064;PowerMockListener(EasyMockAnnotationEnabler.class)
+ * &#064;PowerMockListener(AnnotationEnabler.class)
  * public class PersonServiceTest {
  * 
  * 	&#064;Mock({&quot;getPerson&quot;, &quot;savePerson&quot;})
@@ -62,4 +66,15 @@ import java.lang.annotation.*;
 @Documented
 public @interface Mock {
 	String[] value() default "";
+
+	/**
+	 * Name of the test subject field to which this mock will be assigned. Use to disambiguate the case where
+     * a mock may be assigned to multiple fields of the same type.
+	 * When set, this mock will be assigned to the given field name in any test subject with a matching field name.
+	 * If not set, injection is to all type-compatible fields in all test subjects.
+	 * A given field name may only be used once, and there must be a matching field in at least one test subject.
+	 *
+	 * @return name of the field to inject to
+	 **/
+	String fieldName() default "";
 }

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationGlobalMetadata.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationGlobalMetadata.java
@@ -1,0 +1,69 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ *
+ */
+class AnnotationGlobalMetadata {
+
+    private final List<AnnotationMockMetadata> qualifiedInjections = new ArrayList<AnnotationMockMetadata>(5);
+
+    private final List<AnnotationMockMetadata> unqualifiedInjections = new ArrayList<AnnotationMockMetadata>(5);
+
+    private final Set<String> qualifiers = new HashSet<String>();
+
+    public List<AnnotationMockMetadata> getQualifiedInjections() {
+        return qualifiedInjections;
+    }
+
+    public List<AnnotationMockMetadata> getUnqualifiedInjections() {
+        return unqualifiedInjections;
+    }
+
+    public void add(List<AnnotationMockMetadata> mocksMetadata) {
+        for (AnnotationMockMetadata mockMetadata : mocksMetadata) {
+            add(mockMetadata);
+        }
+    }
+
+    private void add(AnnotationMockMetadata mockMetadata) {
+
+        String qualifier = mockMetadata.getQualifier();
+
+        if (qualifier.length() != 0) {
+            blockDuplicateQualifiers(qualifier);
+            qualifiedInjections.add(mockMetadata);
+        } else {
+            unqualifiedInjections.add(mockMetadata);
+        }
+    }
+
+    private void blockDuplicateQualifiers(String qualifier) {
+        if (!qualifiers.add(qualifier)) {
+            throw new RuntimeException(String.format("At least two mocks have fieldName qualifier '%s'", qualifier));
+        }
+    }
+
+
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockCreator.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockCreator.java
@@ -1,0 +1,27 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import java.lang.reflect.Method;
+
+/**
+ *
+ */
+interface AnnotationMockCreator {
+    Object createMockInstance(final Class<?> type, final Method[] methods);
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockCreatorFactory.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockCreatorFactory.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import java.lang.reflect.Method;
+
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.createNiceMock;
+import static org.powermock.api.easymock.PowerMock.createStrictMock;
+
+/**
+ *
+ */
+class AnnotationMockCreatorFactory {
+    public AnnotationMockCreator createDefaultMockCreator() {
+        return new AnnotationMockCreator() {
+            @Override
+            public Object createMockInstance(Class<?> type, Method[] methods) {
+                return createMock(type, methods);
+            }
+        };
+    }
+
+    public AnnotationMockCreator createNiceMockCreator() {
+        return new AnnotationMockCreator() {
+            @Override
+            public Object createMockInstance(Class<?> type, Method[] methods) {
+                return createNiceMock(type, methods);
+            }
+        };
+    }
+
+    public AnnotationMockCreator createStrictMockCreator() {
+        return new AnnotationMockCreator() {
+            @Override
+            public Object createMockInstance(Class<?> type, Method[] methods) {
+                return createStrictMock(type, methods);
+            }
+        };
+    }
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockMetadata.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockMetadata.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import org.powermock.reflect.Whitebox;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+@SuppressWarnings("WeakerAccess")
+public class AnnotationMockMetadata {
+    private final Class<?> type;
+    private final Method[] methods;
+    private final String qualifier;
+    private final Class<? extends Annotation> annotation;
+    private final Annotation annotationInstance;
+    private Object mock;
+    
+    public AnnotationMockMetadata(Class<? extends Annotation> annotation, Field field) throws
+            Exception {
+        this.annotation = annotation;
+        this.annotationInstance = field.getAnnotation(annotation);
+        this.type = field.getType();
+        this.methods = getMethod();
+        this.qualifier = findQualifier();
+    }
+
+    private String findQualifier() {
+        String fieldName = "";
+        try {
+            fieldName = Whitebox.invokeMethod(annotationInstance, "fieldName");
+        } catch (Exception e) {
+            // do nothing, because it means that Mock annotation doesn't support qualifier. S
+            // ee org.easymock.Mock.fieldName
+        }
+
+        if (fieldName.length() == 0) {
+            return "";
+        } else {
+            return fieldName;
+        }
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public Class<? extends Annotation> getAnnotation() {
+        return annotation;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    public Method[] getMethods() {
+        return methods;
+    }
+
+    private Method[] getMethod() throws Exception {
+
+        final String[] value = Whitebox.invokeMethod(annotationInstance, "value");
+        if (value.length != 1 || !"".equals(value[0])) {
+            return Whitebox.getMethods(type, value);
+        }
+        return null;
+    }
+
+    public Object getMock() {
+        return mock;
+    }
+
+    public void setMock(Object mock) {
+        this.mock = mock;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        AnnotationMockMetadata that = (AnnotationMockMetadata) o;
+
+        if (type != null ? !type.equals(that.type) : that.type != null) { return false; }
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        return Arrays.equals(methods, that.methods) && (qualifier != null ? qualifier.equals(that.qualifier) : that.qualifier == null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + Arrays.hashCode(methods);
+        result = 31 * result + (qualifier != null ? qualifier.hashCode() : 0);
+        return result;
+    }
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockScanner.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockScanner.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import org.powermock.reflect.Whitebox;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+class AnnotationMockScanner {
+    private final Class<? extends Annotation> annotation;
+
+    public AnnotationMockScanner(Class<? extends Annotation> annotation) {
+        this.annotation = annotation;
+    }
+
+    public List<AnnotationMockMetadata> scan(Object instance) throws Exception {
+        final List<AnnotationMockMetadata> mocksMetadata = new ArrayList<AnnotationMockMetadata>();
+        final Set<Field> fields = getFields(instance);
+        for (Field field : fields) {
+            if (field.get(instance) != null) {
+                continue;
+            }
+            mocksMetadata.add(new AnnotationMockMetadata(annotation, field));
+        }
+        return mocksMetadata;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Field> getFields(Object instance) {
+        final Set<Field> fields;
+        if (annotation != null) {
+            fields = Whitebox.getFieldsAnnotatedWith(instance, annotation);
+        }else{
+            fields = Whitebox.getAllInstanceFields(instance);
+        }
+        return fields;
+    }
+
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/EasyMockAnnotationSupport.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/EasyMockAnnotationSupport.java
@@ -1,0 +1,135 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import org.powermock.api.easymock.EasyMockConfiguration;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.api.easymock.annotation.MockNice;
+import org.powermock.api.easymock.annotation.MockStrict;
+import org.powermock.reflect.Whitebox;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class works like as {@link org.easymock.EasyMockSupport} and is used to create and inject mocks to
+ * annotated fields of an instance of test class.
+ * @see Mock
+ * @see org.easymock.Mock
+ * @see org.easymock.TestSubject
+ */
+@SuppressWarnings("WeakerAccess")
+public class EasyMockAnnotationSupport {
+
+    private final Object testInstance;
+    private final AnnotationMockCreatorFactory annotationMockCreatorFactory;
+    private final AnnotationGlobalMetadata globalMetadata;
+    private final EasyMockConfiguration easyMockConfiguration;
+
+    public EasyMockAnnotationSupport(Object testInstance) {
+        this.testInstance = testInstance;
+        this.annotationMockCreatorFactory = new AnnotationMockCreatorFactory();
+        this.globalMetadata = new AnnotationGlobalMetadata();
+        this.easyMockConfiguration = EasyMockConfiguration.getConfiguration();
+    }
+
+    public void injectMocks() throws Exception {
+        injectStrictMocks();
+        injectNiceMocks();
+        injectDefaultMocks();
+        injectTestSubjectMocks();
+    }
+
+    protected void injectStrictMocks() throws Exception {
+        inject(testInstance, MockStrict.class, annotationMockCreatorFactory.createStrictMockCreator());
+    }
+
+    protected void injectNiceMocks() throws Exception {
+        inject(testInstance, MockNice.class, annotationMockCreatorFactory.createNiceMockCreator());
+    }
+
+    @SuppressWarnings("deprecation")
+    protected void injectDefaultMocks() throws Exception {
+        inject(testInstance, Mock.class, annotationMockCreatorFactory.createDefaultMockCreator());
+        inject(testInstance, org.powermock.core.classloader.annotations.Mock.class, annotationMockCreatorFactory.createDefaultMockCreator());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void injectTestSubjectMocks() throws IllegalAccessException {
+        if (easyMockConfiguration.isTestSubjectSupported()) {
+            TestSubjectInjector testSubjectInjector = new TestSubjectInjector(testInstance, globalMetadata);
+            testSubjectInjector.injectTestSubjectMocks();
+        }
+    }
+
+
+    protected void inject(Object injectCandidateInstance, Class<? extends Annotation> annotation, AnnotationMockCreator mockCreator) throws Exception {
+
+        AnnotationMockScanner scanner = new AnnotationMockScanner(annotation);
+
+        List<AnnotationMockMetadata> mocksMetadata = scanner.scan(injectCandidateInstance);
+        globalMetadata.add(mocksMetadata);
+
+        for (AnnotationMockMetadata mockMetadata : mocksMetadata) {
+            injectMock(injectCandidateInstance, mockMetadata, mockCreator, new AnnotationInjectFieldSearcher());
+        }
+
+
+    }
+
+    protected void injectMock(Object injectCandidateInstance, AnnotationMockMetadata mockMetadata,
+                              AnnotationMockCreator mockCreator, InjectFieldSearcher fieldSearch) throws IllegalAccessException {
+        Object mock = createMock(mockCreator, mockMetadata);
+        Field field = fieldSearch.findField(injectCandidateInstance, mockMetadata);
+        if (field != null && mock != null) {
+            field.setAccessible(true);
+            field.set(injectCandidateInstance, mock);
+        }
+    }
+
+
+    protected Object createMock(AnnotationMockCreator mockCreator, AnnotationMockMetadata mockMetadata) {
+        if (mockMetadata.getMock() == null) {
+            Object mock = mockCreator.createMockInstance(mockMetadata.getType(), mockMetadata.getMethods());
+            mockMetadata.setMock(mock);
+        }
+        return mockMetadata.getMock();
+    }
+
+
+    protected interface InjectFieldSearcher {
+        Field findField(Object instance, AnnotationMockMetadata mockMetadata);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    protected static class AnnotationInjectFieldSearcher implements InjectFieldSearcher {
+
+        @Override
+        public Field findField(Object instance, AnnotationMockMetadata mockMetadata) {
+            Set<Field> candidates = Whitebox.getFieldsAnnotatedWith(instance, mockMetadata.getAnnotation());
+            if (candidates.size() == 1) {
+                return candidates.iterator().next();
+            }
+            return null;
+        }
+    }
+    
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/TestSubjectInjector.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/TestSubjectInjector.java
@@ -1,0 +1,155 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.api.extension.listener;
+
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.powermock.reflect.Whitebox;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The class injects mocks created with {@link Mock}, {@link org.powermock.api.easymock.annotation.Mock}
+ * and {@link org.powermock.core.classloader.annotations.Mock} to fields of objects which is annotated with {@link TestSubject}
+ * @see TestSubject
+ * @since 1.6.5
+ */
+@SuppressWarnings({"deprecation", "WeakerAccess"})
+class TestSubjectInjector {
+
+    private final Object testInstance;
+    private final AnnotationGlobalMetadata globalMetadata;
+
+    public TestSubjectInjector(Object testInstance, AnnotationGlobalMetadata globalMetadata) {
+
+        this.testInstance = testInstance;
+        this.globalMetadata = globalMetadata;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void injectTestSubjectMocks() throws IllegalAccessException {
+
+        Set<Field> testSubjectFields = Whitebox.getFieldsAnnotatedWith(testInstance, TestSubject.class);
+        for (Field testSubjectField : testSubjectFields) {
+            Object testSubject = testSubjectField.get(testInstance);
+            if (testSubject == null) {
+                throw new NullPointerException("Have you forgotten to instantiate " + testSubjectField.getName() + "?");
+            }
+            injectTestSubjectFields(testSubject);
+
+        }
+    }
+
+    protected void injectTestSubjectFields(Object testSubject) throws IllegalAccessException {
+        Set<Field> targetFields = new HashSet<Field>(Whitebox.getAllInstanceFields(testSubject));
+        targetFields = injectByName(targetFields, testSubject);
+        injectByType(targetFields, testSubject);
+    }
+
+    void injectByType(Set<Field> targetFields, Object testSubject) throws IllegalAccessException {
+        for (Field targetField : targetFields) {
+
+            InjectionTarget target = new InjectionTarget(targetField);
+
+            AnnotationMockMetadata toAssign = findUniqueAssignable(target);
+
+            if (toAssign == null) {
+                continue;
+            }
+
+            target.inject(testSubject, toAssign);
+        }
+    }
+
+    AnnotationMockMetadata findUniqueAssignable(InjectionTarget target) {
+        AnnotationMockMetadata toAssign = null;
+        for (AnnotationMockMetadata mockMetadata : globalMetadata.getUnqualifiedInjections()) {
+            if (target.accepts(mockMetadata)) {
+                if (toAssign != null) {
+                    throw new RuntimeException(String.format("At least two mocks can be assigned to '%s': %s and %s", target.getField(), toAssign.getMock(), mockMetadata.getMock()));
+                }
+                toAssign = mockMetadata;
+            }
+        }
+        return toAssign;
+    }
+
+    Set<Field> injectByName(Set<Field> targetFields, Object targetObject) throws IllegalAccessException {
+        Class<?> targetClass = targetObject.getClass();
+
+        for (AnnotationMockMetadata mockMetadata : globalMetadata.getQualifiedInjections()) {
+            Field targetField = getFieldByName(targetClass, mockMetadata.getQualifier());
+
+            if (targetField == null) {
+                continue;
+            }
+
+            InjectionTarget target = new InjectionTarget(targetField);
+
+            if (target.accepts(mockMetadata)) {
+                target.inject(targetObject, mockMetadata);
+                targetFields.remove(targetField);
+            }
+        }
+
+        return targetFields;
+    }
+
+    private Field getFieldByName(Class<?> clazz, String fieldName) {
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            return null;
+        } catch (SecurityException e) {
+            // ///CLOVER:OFF
+            return null;
+            // ///CLOVER:ON
+        }
+    }
+
+    private static class InjectionTarget {
+
+        private final Field field;
+
+        public InjectionTarget(Field field) {
+
+            this.field = field;
+        }
+
+        public Field getField() {
+            return field;
+        }
+
+        public boolean accepts(AnnotationMockMetadata mockMetadata) {
+            return field.getType().isAssignableFrom(mockMetadata.getType());
+        }
+
+        public void inject(Object targetObject, AnnotationMockMetadata mockMetadata) throws IllegalAccessException {
+            field.setAccessible(true);
+
+            Object value = field.get(targetObject);
+
+            if (value == null) {
+                field.set(targetObject, mockMetadata.getMock());
+            }
+        }
+
+    }
+}

--- a/api/easymock/src/main/java/org/powermock/api/extension/listener/TestSubjectInjector.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/listener/TestSubjectInjector.java
@@ -118,9 +118,7 @@ class TestSubjectInjector {
         } catch (NoSuchFieldException e) {
             return null;
         } catch (SecurityException e) {
-            // ///CLOVER:OFF
             return null;
-            // ///CLOVER:ON
         }
     }
 

--- a/modules/module-test/easymock/junit4-agent/pom.xml
+++ b/modules/module-test/easymock/junit4-agent/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-modules-easymock-test</artifactId>
+        <version>1.6.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powermock-module-test-easymock-junit4-agent</artifactId>
+    <name>${project.artifactId}</name>
+
+    <description>
+        Tests for PowerMock Java agent with JUnit4 and Easymock
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4-rule-agent</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        -javaagent:${settings.localRepository}//org/powermock/powermock-module-javaagent/${project.version}/powermock-module-javaagent-${project.version}.jar
+                    </argLine>
+                    <useSystemClassloader>true</useSystemClassloader>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/module-test/easymock/junit4-agent/src/test/java/powermock/modules/test/mockito/junit4/agent/AnnotationUsageTest.java
+++ b/modules/module-test/easymock/junit4-agent/src/test/java/powermock/modules/test/mockito/junit4/agent/AnnotationUsageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package powermock.modules.test.mockito.junit4.agent;
+
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import samples.Service;
+import samples.annotationbased.AnnotationDemo;
+
+import java.util.Arrays;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.easymock.PowerMock.replay;
+
+@RunWith(Parameterized.class)
+public class AnnotationUsageTest {
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
+
+
+    @TestSubject
+    private final
+    AnnotationDemo tested = new AnnotationDemo();
+
+
+    @SuppressWarnings("unused")
+    @Mock
+    private Service server;
+
+    private final String fooId;
+
+
+    public AnnotationUsageTest(String fooId) {
+        this.fooId = fooId;
+    }
+
+
+    @Parameterized.Parameters()
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"1"},
+                {"2"}
+        });
+    }
+
+
+    @Before
+    public void setUp() {
+        expect(server.getServiceMessage()).andReturn(fooId);
+        replay(server);
+    }
+
+
+    @Test
+    public void annotationsAreEnabledWhenUsingTheJUnitRule() {
+        String serviceMessage = tested.getServiceMessage();
+        assertEquals(fooId, serviceMessage);
+    }
+}

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/annotationbased/TestSubjectEasymockAnnotationTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/annotationbased/TestSubjectEasymockAnnotationTest.java
@@ -1,0 +1,44 @@
+package samples.junit4.annotationbased;
+
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import samples.injectmocks.InjectDemo;
+import samples.injectmocks.InjectDependencyHolder;
+import samples.injectmocks.InjectDependencyHolderQualifier;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Asserts that {@link @TestSubject} with PowerMock and mock witch created via @org.easymock.Mock.
+ */
+@RunWith(PowerMockRunner.class)
+public class TestSubjectEasymockAnnotationTest {
+
+    @SuppressWarnings("unused")
+    @Mock
+    private InjectDemo injectDemoEasymock;
+
+    @TestSubject
+    private final InjectDependencyHolder dependencyHolder = new InjectDependencyHolder();
+
+    @SuppressWarnings("unused")
+    @Mock(fieldName = "injectDemoQualifier")
+    private InjectDemo injectDemoQualifierEasymock;
+
+    @TestSubject
+    private final InjectDependencyHolderQualifier dependencyHolderQualifier = new InjectDependencyHolderQualifier();
+
+    @Test
+    public void injectMocksWorksWithEasymock() {
+        assertNotNull("dependencyHolder is null", dependencyHolder.getInjectDemo());
+    }
+
+    @Test
+    public void injectMocksWorksWithEasymockQualifier() {
+        assertNotNull("dependencyHolder is null", dependencyHolderQualifier.getInjectDemoQualifier());
+    }
+
+}

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/annotationbased/TestSubjectPowermockAnnotationTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/annotationbased/TestSubjectPowermockAnnotationTest.java
@@ -1,0 +1,80 @@
+package samples.junit4.annotationbased;
+
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import samples.injectmocks.InjectDemo;
+import samples.injectmocks.InjectDependencyHolder;
+import samples.injectmocks.InjectDependencyHolderQualifier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.easymock.PowerMock.expectPrivate;
+import static org.powermock.api.easymock.PowerMock.replay;
+
+/**
+ * Asserts that {@link @TestSubject} with PowerMock and mock witch created via @org.powermock.api.easymock.annotation.Mock.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(InjectDemo.class)
+public class TestSubjectPowermockAnnotationTest {
+
+    @SuppressWarnings("unused")
+    @Mock
+    private InjectDemo injectDemoEasymock;
+
+    @TestSubject
+    private final InjectDependencyHolder dependencyHolder = new InjectDependencyHolder();
+
+    @SuppressWarnings("unused")
+    @Mock(fieldName = "injectDemoQualifier")
+    private InjectDemo injectDemoQualifierEasymock;
+
+    @TestSubject
+    private final InjectDependencyHolderQualifier dependencyHolderQualifier = new InjectDependencyHolderQualifier();
+
+
+    @Test
+    public void injectMocksWorksWithPowermockMock() {
+        assertNotNull("dependencyHolder is null", dependencyHolder.getInjectDemo());
+    }
+
+    @Test
+    public void testInjectDemoSay() throws Exception {
+
+        InjectDemo tested = dependencyHolder.getInjectDemo();
+
+        String expected = "Hello altered World";
+        expectPrivate(tested,"say","hello").andReturn("Hello altered World");
+        replay(tested);
+
+        String actual = Whitebox.invokeMethod(tested,"say", "hello");
+
+        assertEquals("Expected and actual did not match", expected, actual);
+    }
+
+    @Test
+    public void injectMocksWorksWithPowermockMockWithQualifier() {
+        assertNotNull("dependencyHolder is null", dependencyHolderQualifier.getInjectDemoQualifier());
+    }
+
+    @Test
+    public void testInjectDemoQualifier() throws Exception {
+
+        InjectDemo tested = dependencyHolderQualifier.getInjectDemoQualifier();
+
+        String expected = "Hello altered World";
+        expectPrivate(tested,"say","hello").andReturn("Hello altered World");
+        replay(tested);
+
+        String actual = Whitebox.invokeMethod(tested,"say", "hello");
+
+        assertEquals("Expected and actual did not match", expected, actual);
+
+    }
+
+}

--- a/modules/module-test/easymock/pom.xml
+++ b/modules/module-test/easymock/pom.xml
@@ -43,5 +43,6 @@
         <module>junit47-test</module>
         <module>junit48-test</module>
         <module>junit410-test</module>
+        <module>junit4-agent</module>
     </modules>
 </project>

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/annotationbased/InjectMocksAnnotationTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/annotationbased/InjectMocksAnnotationTest.java
@@ -24,7 +24,14 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import samples.finalmocking.FinalDemo;
 import samples.injectmocks.DependencyHolder;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Asserts that {@link @InjectMocks} with PowerMock.
@@ -41,7 +48,28 @@ public class InjectMocksAnnotationTest {
 	private DependencyHolder dependencyHolder = new DependencyHolder();
 
 	@Test
-	public void injectMocksWorks() throws Exception {
+	public void injectMocksWorks() {
 		assertNotNull(dependencyHolder.getFinalDemo());
+	}
+
+	@Test
+	public void testSay() throws Exception {
+
+		FinalDemo tested = dependencyHolder.getFinalDemo();
+
+		String expected = "Hello altered World";
+		when(tested.say("hello")).thenReturn("Hello altered World");
+
+		String actual = tested.say("hello");
+
+		assertEquals("Expected and actual did not match", expected, actual);
+
+		// Should still be mocked by now.
+		try {
+			verify(tested).say("world");
+			fail("Should throw AssertionError!");
+		} catch (AssertionError e) {
+			assertThat(e.getMessage(), is(containsString("Argument(s) are different! Wanted")));
+		}
 	}
 }

--- a/tests/utils/src/main/java/samples/annotationbased/AnnotationDemo.java
+++ b/tests/utils/src/main/java/samples/annotationbased/AnnotationDemo.java
@@ -19,10 +19,14 @@ import samples.Service;
 
 public class AnnotationDemo {
 
-	private final Service service;
+	private Service service;
 
 	public AnnotationDemo(Service service) {
 		this.service = service;
+	}
+
+	public AnnotationDemo() {
+
 	}
 
 	public String getServiceMessage() {

--- a/tests/utils/src/main/java/samples/injectmocks/DependencyHolderQualifier.java
+++ b/tests/utils/src/main/java/samples/injectmocks/DependencyHolderQualifier.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package samples.injectmocks;
+
+import samples.finalmocking.FinalDemo;
+
+/**
+ * Simple class used to demonstrate setter injection..
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class DependencyHolderQualifier {
+
+	private FinalDemo finalDemo;
+	private FinalDemo finalDemoQualifier;
+
+	public FinalDemo getFinalDemo() {
+		return finalDemo;
+	}
+
+	public void setFinalDemo(FinalDemo finalDemo) {
+		this.finalDemo = finalDemo;
+	}
+
+	public FinalDemo getFinalDemoQualifier() {
+		return finalDemoQualifier;
+	}
+
+	public void setFinalDemoQualifier(FinalDemo finalDemoQualifier) {
+		this.finalDemoQualifier = finalDemoQualifier;
+	}
+}

--- a/tests/utils/src/main/java/samples/injectmocks/InjectDemo.java
+++ b/tests/utils/src/main/java/samples/injectmocks/InjectDemo.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package samples.injectmocks;
+
+/**
+ *
+ */
+@SuppressWarnings({"SameReturnValue", "unused"})
+public class InjectDemo {
+
+    @SuppressWarnings("unused")
+    public String getMessage() {
+        return say("hello");
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    private String say(String hello) {
+        return hello;
+    }
+
+}

--- a/tests/utils/src/main/java/samples/injectmocks/InjectDependencyHolder.java
+++ b/tests/utils/src/main/java/samples/injectmocks/InjectDependencyHolder.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package samples.injectmocks;
+
+/**
+ * Simple class used to demonstrate setter injection..
+ */
+@SuppressWarnings("unused")
+public class InjectDependencyHolder {
+
+	private InjectDemo injectDemo;
+
+    public InjectDemo getInjectDemo() {
+        return injectDemo;
+    }
+
+    public void setInjectDemo(InjectDemo injectDemo) {
+        this.injectDemo = injectDemo;
+    }
+}

--- a/tests/utils/src/main/java/samples/injectmocks/InjectDependencyHolderQualifier.java
+++ b/tests/utils/src/main/java/samples/injectmocks/InjectDependencyHolderQualifier.java
@@ -1,0 +1,43 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package samples.injectmocks;
+
+/**
+ * Simple class used to demonstrate setter injection..
+ */
+@SuppressWarnings("unused")
+public class InjectDependencyHolderQualifier {
+
+	private InjectDemo injectDemo;
+    private InjectDemo injectDemoQualifier;
+
+    public InjectDemo getInjectDemo() {
+        return injectDemo;
+    }
+
+    public void setInjectDemo(InjectDemo injectDemo) {
+        this.injectDemo = injectDemo;
+    }
+
+    public InjectDemo getInjectDemoQualifier() {
+        return injectDemoQualifier;
+    }
+
+    public void setInjectDemoQualifier(InjectDemo injectDemoQualifier) {
+        this.injectDemoQualifier = injectDemoQualifier;
+    }
+}


### PR DESCRIPTION
Support of @TestSubject  was added. (EasyMock's equivalent to Mockito's @InjectMocks)
The class could be used to determine whether EasyMock supports some feature or not. 
